### PR TITLE
add instructions to use cf create-service

### DIFF
--- a/rds-data/README.md
+++ b/rds-data/README.md
@@ -6,7 +6,7 @@ In order to run the sample application, please execute the following steps:
 Create a VPC Endpoint to the service `rds-data` eg. `com.amazonaws.us-east-1.rds-data`.
 Note the hostname, it should look similar to `vpce-00000000000000000-00000000.rds-data.us-east-1.vpce.amazonaws.com`.
 
-If using the SAP Private Link service, create a service instance using the following command:
+If using the SAP Private Link service, create a service instance using the following command - this will create the interface endpoint for you:
 ```bash 
 # adapt the region in the service name if using a different region
 cf create-service privatelink standard my-service-instance-name -c '{"serviceName": "com.amazonaws.eu-central-1.rds-data"}'

--- a/s3/README.md
+++ b/s3/README.md
@@ -16,7 +16,7 @@ If you only want to test certain parts (i.e. only the bucket access, but don't c
 
 Create a VPC Endpoint to the service `com.amazonaws.us-east-1.s3` with type `interface`.
 
-If using the SAP Private Link service, create a service instance using the following command:
+If using the SAP Private Link service, create a service instance using the following command - this will create the interface endpoint for you:
 ```bash 
 # adapt the region in the service name if using a different region
 cf create-service privatelink standard my-service-instance-name -c '{"serviceName": "com.amazonaws.eu-central-1.s3"}'

--- a/ses/README.md
+++ b/ses/README.md
@@ -7,7 +7,7 @@ Create a VPC Endpoint to the service `email-smtp` (using the API to send mails v
 eg. `com.amazonaws.us-east-1.email-smtp`.
 Note the hostname, it should look similar to `vpce-00000000000000000-00000000.email-smtp.us-east-1.vpce.amazonaws.com`.
 
-If using the SAP Private Link service, create a service instance using the following command:
+If using the SAP Private Link service, create a service instance using the following command - this will create the interface endpoint for you:
 ```bash 
 # adapt the region in the service name if using a different region
 cf create-service privatelink standard my-service-instance-name -c '{"serviceName": "com.amazonaws.eu-central-1.email-smtp"}'

--- a/sns/README.md
+++ b/sns/README.md
@@ -6,7 +6,7 @@ In order to run the sample application, please execute the following steps:
 Create a VPC Endpoint to the service `sns` eg. `com.amazonaws.us-east-1.sns`.
 Note the hostname, it should look similar to `vpce-00000000000000000-00000000.sns.us-east-1.vpce.amazonaws.com`.
 
-If using the SAP Private Link service, create a service instance using the following command:
+If using the SAP Private Link service, create a service instance using the following command - this will create the interface endpoint for you:
 ```bash 
 # adapt the region in the service name if using a different region
 cf create-service privatelink standard my-service-instance-name -c '{"serviceName": "com.amazonaws.eu-central-1.sns"}'

--- a/sqs/README.md
+++ b/sqs/README.md
@@ -6,7 +6,7 @@ In order to run the sample application, please execute the following steps:
 Create a VPC Endpoint to the service `sqs` eg. `com.amazonaws.us-east-1.sqs`.
 Note the hostname, it should look similar to `vpce-00000000000000000-00000000.sqs.us-east-1.vpce.amazonaws.com`.
 
-If using the SAP Private Link service, create a service instance using the following command:
+If using the SAP Private Link service, create a service instance using the following command - this will create the interface endpoint for you:
 ```bash 
 # adapt the region in the service name if using a different region
 cf create-service privatelink standard my-service-instance-name -c '{"serviceName": "com.amazonaws.eu-central-1.sns"}'


### PR DESCRIPTION
I think it would be nice to not only describe the creation for interface endpoints but the actual `cf create-service` commands when using the SAP BTP Private Link service.